### PR TITLE
fix: Docker 빌드 시 .env.local이 복사되어 프로덕션 환경 변수가 무시되는 문제 해결

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,8 +40,8 @@ Thumbs.db
 
 Dockerfile
 dockerfile.local
-.env.local
-.env.development
+.env*
+!.env.production
 .cache
 .parcel-cache
 yarn-error.log*


### PR DESCRIPTION
- .dockerignore에 .env* 추가하여 모든 env 파일 제외
- !.env.production으로 프로덕션 환경 파일만 예외 처리
- 이제 빌드 시 S3에서 다운로드한 .env.production만 사용됨